### PR TITLE
Fix: Change OKP JWK thumbprint to use crv/kty/x, not RSA's kty/n/x

### DIFF
--- a/lib/jwt/eddsa/jwk/okp.rb
+++ b/lib/jwt/eddsa/jwk/okp.rb
@@ -7,7 +7,7 @@ module JWT
       class OKP < ::JWT::JWK::KeyBase
         KTY  = "OKP"
         KTYS = [KTY, JWT::EdDSA::JWK::OKP, Ed25519::SigningKey, Ed25519::VerifyKey].freeze
-        OKP_PUBLIC_KEY_ELEMENTS = %i[kty n x].freeze
+        OKP_PUBLIC_KEY_ELEMENTS = %i[crv kty x].freeze
         OKP_PRIVATE_KEY_ELEMENTS = %i[d].freeze
 
         def initialize(key, params = nil, options = {})

--- a/spec/jwt/jwk/okp_spec.rb
+++ b/spec/jwt/jwk/okp_spec.rb
@@ -73,6 +73,16 @@ RSpec.describe JWT::EdDSA::JWK::OKP do
     end
   end
 
+  describe "#kid" do
+    # Test vector from RFC 8037 Appendix A.3 (JWK Thumbprint Canonicalization):
+    # https://www.rfc-editor.org/rfc/rfc8037#appendix-A.3
+    let(:key) { { kty: "OKP", crv: "Ed25519", x: "11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo" } }
+
+    it "matches the RFC 7638 JWK thumbprint of the crv/kty/x members" do
+      expect(instance.kid).to eq("kPrK_qmxVWaYVA9wwBF6Iuo3vVzz7TxHCTwXBygrS4k")
+    end
+  end
+
   describe "#export" do
     let(:options) { {} }
     subject { instance.export(options) }


### PR DESCRIPTION
### Description

Fix OKP JWK thumbprint: use crv/kty/x, not RSA's kty/n/x

OKP_PUBLIC_KEY_ELEMENTS was copy-pasted from an RSA-shaped element list (kty, n, x). "n" is the RSA modulus and never applies to OKP (Ed25519) keys, so it always serialized as null; "crv" is required by RFC 8037 but was missing entirely.

This list feeds `JWK::OKP#members`, which `JWT::JWK::Thumbprint` (RFC 7638) uses directly to compute the SHA-256 thumbprint, and jwt's default kid_generator (:key_digest) uses that thumbprint as the auto-generated "kid" for every key this gem creates. As a result, every kid produced by this gem is computed over the wrong JSON (`{"kty":"OKP","n":null,"x":"..."}`) instead of the RFC 7638-correct `{"crv":"Ed25519","kty":"OKP","x":"..."}`, so it never matches the thumbprint a spec-compliant verifier computes for the same key.

Add a regression test pinned to the published RFC 8037 Appendix A.3 thumbprint test vector.

### Checklist

Before the PR can be merged be sure the following are checked:
* [X] There are tests for the fix or feature added/changed

### Notes

I stumbled upon this issue after investigating why JWK keys generated by [Linzer](https://github.com/nomadium/linzer) gem (which depends on jwt-eddsa) and associated HTTP message signatures were failing verification at a [CloudFlare debug utility website](https://http-message-signatures-example.research.cloudflare.com/debug).
