### PR TITLE
ci: Migrate from the defunct release-please app to release-please-action

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -1,2 +1,0 @@
-handleGHRelease: true
-manifest: true

--- a/.github/workflows/gem-push.yml
+++ b/.github/workflows/gem-push.yml
@@ -12,10 +12,12 @@
         contents: write
         id-token: write
       steps:
-      - uses: rubygems/configure-rubygems-credentials@main
+      - uses: rubygems/configure-rubygems-credentials@dc5a8d8553e6ee01fc26761a49e99e733d17954a # v2.1.0
         with:
           role-to-assume: rg_oidc_akr_d5dztzq4ywp3y7rd7vfp
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Set remote URL
         run: |
           # Attribute commits to the last committer on HEAD
@@ -23,10 +25,12 @@
           git config --global user.name "$(git log -1 --pretty=format:'%an')"
           git remote set-url origin "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/$GITHUB_REPOSITORY"
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
         with:
-          bundler-cache: true
+          bundler-cache: false
           ruby-version: ruby
+      - name: Install dependencies
+        run: bundle install
       - name: Extract version number
         run: echo "GEM_VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_ENV
       - name: Release

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,5 +1,8 @@
 name: PR Conventional Commit Validation
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     types: [opened, synchronize, reopened, edited]
@@ -9,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: PR Conventional Commit Validation
-        uses:  ytanikin/PRConventionalCommits@1.2.0
+        uses: ytanikin/PRConventionalCommits@8d258b54939f6769fcd935a52b96d6b0383a00c5 # 1.2.0
         with:
           task_types: '["feat","fix","docs","test","ci","refactor","perf","chore","revert"]'
           add_label: 'false'

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -41,8 +41,10 @@
       - name: Set up Ruby
         uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
         with:
-          bundler-cache: true
+          bundler-cache: false
           ruby-version: ruby
+      - name: Install dependencies
+        run: bundle install
       - name: Release
         run: bundle exec rake release
       - name: Wait for release to propagate

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,56 @@
+---
+  on:
+    push:
+      branches:
+      - main
+
+  name: release-please
+  jobs:
+    release-please:
+      runs-on: ubuntu-latest
+      permissions:
+        contents: write
+        pull-requests: write
+      outputs:
+        release_created: ${{ steps.release.outputs.release_created }}
+        tag_name: ${{ steps.release.outputs.tag_name }}
+      steps:
+      - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
+        id: release
+
+    push-gem:
+      needs: release-please
+      if: ${{ needs.release-please.outputs.release_created == 'true' }}
+      runs-on: ubuntu-latest
+      permissions:
+        contents: write
+        id-token: write
+      steps:
+      - uses: rubygems/configure-rubygems-credentials@dc5a8d8553e6ee01fc26761a49e99e733d17954a # v2.1.0
+        with:
+          role-to-assume: rg_oidc_akr_d5dztzq4ywp3y7rd7vfp
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Set remote URL
+        run: |
+          # Attribute commits to the last committer on HEAD
+          git config --global user.email "$(git log -1 --pretty=format:'%ae')"
+          git config --global user.name "$(git log -1 --pretty=format:'%an')"
+          git remote set-url origin "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/$GITHUB_REPOSITORY"
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
+        with:
+          bundler-cache: true
+          ruby-version: ruby
+      - name: Release
+        run: bundle exec rake release
+      - name: Wait for release to propagate
+        run: |
+          gem install rubygems-await
+          gem_tuple="$(ruby -rbundler/setup -rbundler -e '
+              spec = Bundler.definition.specs.find {|s| s.name == ARGV[0] }
+              raise "No spec for #{ARGV[0]}" unless spec
+              print [spec.name, spec.version, spec.platform].join(":")
+            ' "jwt-eddsa")"
+          gem await "${gem_tuple}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,6 +40,7 @@ jobs:
           - "3.2"
           - "3.3"
           - "3.4"
+          - "4.0"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,7 @@
 ---
 name: test
+permissions:
+  contents: read
 on:
   push:
     branches:
@@ -13,9 +15,11 @@ jobs:
     timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
         with:
           ruby-version: ruby
           bundler-cache: true
@@ -37,10 +41,12 @@ jobs:
           - "3.3"
           - "3.4"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true


### PR DESCRIPTION
## Why

The release-please GitHub App was turned down by Google on 2025-08-14 (googleapis/release-please#2569). The `.github/release-please.yml` app config has been dead since then — no release PR was opened for the releasable commits currently on `main`, and none ever will be.

## What

- Delete the obsolete `.github/release-please.yml` app config.
- Add `.github/workflows/release-please.yml` using `googleapis/release-please-action@v5`, which reads the existing `release-please-config.json` and `.release-please-manifest.json` unchanged. On every push to `main` it opens/updates the release PR; when the release PR is merged it creates the tag and GitHub release.
- Publish the gem from a second job in the same workflow (same steps as `gem-push.yml`), gated on `release_created`. This is needed because tags created with the workflow's `GITHUB_TOKEN` cannot trigger the tag-based `gem-push.yml` workflow (GitHub anti-recursion rule). `gem-push.yml` is left in place as a fallback for manually pushed tags.
- All actions SHA-pinned and `persist-credentials: false` on checkout; `zizmor` reports no findings.

## Action required before the first release

The RubyGems OIDC role (`rg_oidc_akr_d5dztzq4ywp3y7rd7vfp`) may be scoped to the `gem-push.yml` workflow. If so, update the role on rubygems.org to also permit `.github/workflows/release-please.yml` before merging the first release PR, or the publish job will fail credential exchange.

🤖 Generated with [Claude Code](https://claude.com/claude-code)